### PR TITLE
Add timeout to Ollama translator

### DIFF
--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -209,7 +209,7 @@ class OllamaTranslator(BaseTranslator):
             model = self.envs["OLLAMA_MODEL"]
         super().__init__(lang_in, lang_out, model)
         self.options = {"temperature": 0}  # 随机采样可能会打断公式标记
-        self.client = ollama.Client()
+        self.client = ollama.Client(timeout = 180)
         self.prompttext = prompt
 
     def translate(self, text):


### PR DESCRIPTION
Add a timeout parameter to the Ollama client initialization to handle non-responsive translation.

* Set the timeout parameter to 180 seconds in the `OllamaTranslator` class's `__init__` method.
