### PR TITLE
Support multiple models in OLLAMA_MODEL

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -78,6 +78,13 @@ set OPENAI_MODEL=gpt-4o-mini
 pdf2zh example.pdf -s openai
 ```
 
+To specify multiple models for `OLLAMA_MODEL`, separate them with `;`:
+
+```bash
+set OLLAMA_MODEL=gemma2;aya-expanse
+pdf2zh example.pdf -s ollama
+```
+
 [⬆️ Back to top](#toc)
 
 ---


### PR DESCRIPTION
Update `OLLAMA_MODEL` to support multiple models separated by `;` and handle timeouts.

* **`pdf2zh/translator.py`**:
  - Modify `OllamaTranslator` class to split `OLLAMA_MODEL` by `;` and handle multiple models.
  - Implement logic to try the next model on timeout and raise an error if all models timeout.

* **`docs/ADVANCED.md`**:
  - Add documentation on specifying multiple models for `OLLAMA_MODEL` using `;`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/7shi/PDFMathTranslate/pull/4?shareId=f0b0f562-5fcc-4237-a400-e21408b6fe60).