### PR TITLE
Fix exception handling in OllamaTranslator

### DIFF
--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -226,6 +226,9 @@ class OllamaTranslator(BaseTranslator):
                 return response["message"]["content"].strip()
             except httpx.TimeoutException:
                 continue
+            except Exception as e:
+                print(f"Exception occurred: {e}")
+                sys.exit(1)
         print("All models timed out")
         sys.exit(1)
 


### PR DESCRIPTION
Handle all exceptions in the `translate` method of the `OllamaTranslator` class.

* Catch all exceptions in the `translate` method.
* Log all exceptions with a print statement.
* Exit the program with `sys.exit(1)` if an exception other than `httpx.TimeoutException` occurs.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/7shi/PDFMathTranslate/pull/5?shareId=05114e6c-9a78-4bdf-9133-5a27ab62482f).