### PR TITLE
Fix OllamaTranslator model handling

### DIFF
--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -206,7 +206,7 @@ class OllamaTranslator(BaseTranslator):
     def __init__(self, lang_in, lang_out, model, envs=None, prompt=None):
         self.set_envs(envs)
         if not model:
-            model = self.envs["OLLAMA_MODEL"].split(";")
+            model = self.envs["OLLAMA_MODEL"]
         super().__init__(lang_in, lang_out, model)
         self.options = {"temperature": 0}  # 随机采样可能会打断公式标记
         self.client = ollama.Client(timeout = 180)
@@ -216,7 +216,7 @@ class OllamaTranslator(BaseTranslator):
         print(len(self.prompt(text, self.prompttext)))
         print(self.prompt(text, self.prompttext)[0])
         print(self.prompt(text, self.prompttext)[1])
-        for model in self.models:
+        for model in self.model.split(";"):
             try:
                 response = self.client.chat(
                     model=model,


### PR DESCRIPTION
Modify the `translate()` method in the `OllamaTranslator` class to handle the split operation.

* Change the initialization of the `model` attribute to not split the model string.
* Update the `translate()` method to split the `model` string using a semicolon delimiter before iterating over the models.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/7shi/PDFMathTranslate/pull/6?shareId=6f486385-e248-448f-a383-fd72746ddaaa).